### PR TITLE
Fix broken fonts

### DIFF
--- a/content/static/main.css
+++ b/content/static/main.css
@@ -38,6 +38,12 @@
     --code: #f06292;
     --preformatted: #ccc;
     --disabled: #111;
+      /* Set sans-serif & mono fonts */
+    --sans-font: -apple-system, BlinkMacSystemFont, "Avenir Next", Avenir,
+    "Nimbus Sans L", Roboto, "Noto Sans", "Segoe UI", Arial, Helvetica,
+    "Helvetica Neue", sans-serif;
+    --mono-font: Consolas, Menlo, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+    --standard-border-radius: 5px;
   }
   /* Add a bit of transparency so light media isn't so glaring in dark mode */
   img,


### PR DESCRIPTION
This was a regression added by my hasty copy pasta-ing to make the website darkmode by default. I accidentally shoved the font vars in the light mode only section.