### PR TITLE
New Calendar

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: Publish to GitHub Pages
+name: Deploy Website
 
 on:
   push:
@@ -6,10 +6,23 @@ on:
       - main
   schedule:
     - cron: "0 * * * *"
+  workflow_dispatch:
 
 jobs:
+  calendar_sync:
+    runs-on: ubuntu-latest
+    name: Sync Calendar
+    steps:
+      - uses: acm-uic/calsync@main
+        with:
+          discord-guild-id: ${{ secrets.DISCORD_EVENTS_SYNC_DISCORD_GUILD_ID }}
+          discord-bot-token: ${{ secrets.DISCORD_EVENTS_SYNC_DISCORD_BOT_TOKEN }}
+          discord-application-id: ${{ secrets.DISCORD_EVENTS_SYNC_DISCORD_APPLICATION_ID }}
+          google-calendar-id: ${{ secrets.DISCORD_EVENTS_SYNC_GOOGLE_CALENDAR_CALENDAR_ID }}
+          google-api-key: ${{ secrets.DISCORD_EVENTS_SYNC_GOOGLE_CALENDAR_API_KEY }}
   publish:
     runs-on: ubuntu-latest
+    name: Publish to GitHub Pages
     steps:
       - name: Check out
         uses: actions/checkout@v1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,10 +23,11 @@ jobs:
       - name: One Make to Rule them all
         run: make all
 
-      - name: Publish generated content to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          branch: gh-pages
-          folder: public
-          git-config-user: "gh-runner"
-          git-config-email: "gh@example.com"
+          path: public/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/scripts/calendar.sh
+++ b/scripts/calendar.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -xe
 
-curl "https://uic.campusgroups.com/ics?uid=6e5c8fe1-dbbd-11ed-902f-0e3e5d452619&type=group&eid=ccad7241c88a1d61aa0a73173e0e9648" |
+curl "https://calendar.google.com/calendar/ical/c_d025da6dd12eef635c3eaadaa5f28ec45c98523cd5241f7248da67632f8522ff%40group.calendar.google.com/public/basic.ics" |
 
 # CRLF<space> is used to fold long lines
 sed -z "s/\r\n //g" |


### PR DESCRIPTION
Resolves #20 and #22.

- Calendar has been changed to a new Google Calendar, which has also been connected with ACM's calsync to the Discord server.
- Build has been migrated to using `actions/upload-pages-artifact` and `actions/deploy-pages`. this should remove the need for a `gh-pages` branch and reduce the size of the git repo.