### PR TITLE
Dev Merge - sitemap update & minor clerical changes

### DIFF
--- a/content/index.org
+++ b/content/index.org
@@ -1,4 +1,4 @@
-#+title: Linux User's Group @ UIC
+#+title: Linux User Group @ UIC
 #+AUTHOR: Soham S Gumaste
 #+OPTIONS: toc:nil
 

--- a/content/opsec.md
+++ b/content/opsec.md
@@ -1,3 +1,8 @@
+---
+author: Kevin Cordero
+date: March 12th, 2025
+title: "Threat Modeling 101: Intro to Operational Security" 
+---
 # Metadata
 This is the markdown transcript for a presentation held on Tuesday, March 12th.
 

--- a/content/vimlab.md
+++ b/content/vimlab.md
@@ -2,7 +2,7 @@
 author:
 - Ethan Wong
 date: October 13, 2023
-title: Vim
+title: VimLab Fall 2023
 ---
 
 # Metadata

--- a/scripts/sitemap.sh
+++ b/scripts/sitemap.sh
@@ -1,14 +1,33 @@
 #!/usr/bin/env bash
 
+# Verbose
 set -xeu
 
+# Variable to collect all the markdown links into
+# Format: [Article Title](Article Link)
 LINKS=$""
 
 for files in $(echo "$@" | tr ' ' '\n' | sort -V); do
-	F="${files#public/}"; 
-	TMP=""
-	printf -v TMP "[${F%.html}]($F)  \n"
-	LINKS="${LINKS}${TMP}"
+  # Parameter Expansion; Remove 'public/' from filename and store into variable F
+  F="${files#public/}"
+  # "TMP" stores the current markdown link to be appended to the list
+  TMP=""
+
+  # Title extraction from HTML. Operates on assumption that each webpage has a title meta tag.
+
+  # find title meta tag with awk
+  TITLE="$(awk '/<title>/ {print $0}' $files)"
+  # abuses awk reformatting - just removes trailing & leading whitespace :)
+  TITLE="$(echo $TITLE | awk '{$1=$1};1')"
+  # parameter expansion again, remove title html tags
+  # e.g. <title>My Title</title> becomes "My Title"
+  TITLE=${TITLE#<title>}
+  TITLE=${TITLE%</title>}
+
+  # Store current markdown link with newline in TMP
+  printf -v TMP "[$TITLE]($F)  \n"
+  # Append TMP to list
+  LINKS="${LINKS}${TMP}"
 done
-		
-pandoc -s --template template.html --metadata-file metadata.yml --metadata-file sitemap.yml -o public/sitemap.html <<< "${LINKS}"
+
+pandoc -s --template template.html --metadata-file metadata.yml --metadata-file sitemap.yml -o public/sitemap.html <<<"${LINKS}"


### PR DESCRIPTION
Updated `scripts/sitemap.sh` to extract the title from every HTML file for display on the sitemap, rather than its filename & absolute path.

Additionally:
- Removed CNAME (already done in main, just syncing dev with main)
- Added minor comments in the Makefile & removed need to mirror static between two folders (no editing required & users can still contribute in the same way)
- Gave Kevin's Opsec article a title and gave the Vimlab article a more descriptive title
- Changed index page's tab title to read "Linux User Group" rather than "Linux User's Group"