### PR TITLE
chore: add `python3` to Nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,12 @@
-{ pkgs ? import <nixpkgs> {} }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
 pkgs.mkShell {
-	packages = with pkgs; [
-		libxslt
-		pandoc
-		rsync
-	];
+  packages = with pkgs; [
+    libxslt
+    pandoc
+    python3
+    rsync
+  ];
 }


### PR DESCRIPTION
Required for `make demo` to spawn a webserver.