### PR TITLE
fixed Makefile edge case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,10 @@ $(foreach d, $(DIRS_PUBLIC), $(shell mkdir -p $(d)))
 
 define MAKE_HTML
 
-$(PUBLIC)/%.html: $(join $(CONTENT)/%, $(1))
+$(PUBLIC):
+	mkdir -p $$@
+
+$(PUBLIC)/%.html: $(join $(CONTENT)/%, $(1)) | $(PUBLIC)
 	$(PANDOC) $$(PANDOC_FILE_SPECIFIC) $$^ -o $$@
 
 endef


### PR DESCRIPTION
Makefile had a bug that if there is no directory in content/ then it wasnt making public folder at all therefore if it only had index.md and static folder it would cause error so fixed that